### PR TITLE
added Most common traffic sources

### DIFF
--- a/explore.py
+++ b/explore.py
@@ -30,6 +30,12 @@ def main(args):
     for p, pv in zip(percentiles, percentile_values):
         print("%2.2f%% of customers spend less than: $%.2f" % (p, pv))
 
+    # Most common Sources of Traffic and counts
+    
+    most_common_sources = explore_utils.find_most_common_traffic_sources(data)
+    print("\nThe most common sources of traffic are :")
+    for source in most_common_sources.index:
+        print(' {}: {}'.format(source,most_common_sources[source]))
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(

--- a/explore.py
+++ b/explore.py
@@ -31,9 +31,9 @@ def main(args):
         print("%2.2f%% of customers spend less than: $%.2f" % (p, pv))
 
     # Most common Sources of Traffic and counts
-    
-    most_common_sources = explore_utils.find_most_common_traffic_sources(data)
-    print("\nThe most common sources of traffic are :")
+    num_of_sources = 6
+    most_common_sources = explore_utils.find_most_common_traffic_sources(data,num_of_sources)
+    print("\nThe {} most common sources of traffic are :".format(num_of_sources))
     for source in most_common_sources.index:
         print(' {}: {}'.format(source,most_common_sources[source]))
 

--- a/explore_utils.py
+++ b/explore_utils.py
@@ -45,14 +45,14 @@ def find_customer_revenue_percentiles(
 
     return values
 
-def find_most_common_traffic_sources(dataset):
-    """Find .
+def find_most_common_traffic_sources(dataset,num=5):
+    """ Find n most common traffic sources
 
     args:
        dataset (Dataset): the google analytics dataset
-
+       num(optional): Number of most common traffic sources to return (by default 5)
     returns:
-       Series of 5 most common traffic sources.
+       Series of n (5 by default) most common traffic sources.
 
     """
-    return dataset.train['trafficSource.source'].value_counts().head()
+    return dataset.train['trafficSource.source'].value_counts().head(num)

--- a/explore_utils.py
+++ b/explore_utils.py
@@ -44,3 +44,15 @@ def find_customer_revenue_percentiles(
               for percentile in percentiles]
 
     return values
+
+def find_most_common_traffic_sources(dataset):
+    """Find .
+
+    args:
+       dataset (Dataset): the google analytics dataset
+
+    returns:
+       Series of 5 most common traffic sources.
+
+    """
+    return dataset.train['trafficSource.source'].value_counts().head()


### PR DESCRIPTION
The output when run using the debug option.

The most common sources of traffic are :
 google: 588
 mall.googleplex.com: 164
 (direct): 90
 Partners: 66
 analytics.google.com: 31
