### PR TITLE
Evaluation script and utils.

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -1,0 +1,78 @@
+from __future__ import print_function
+
+import os
+import argparse
+
+import pandas as pd
+import numpy as np
+
+
+def main(args):
+    """Evaluate the Log-RMSE of a set of predictions.
+
+    Log-RMSE = sqrt( 1 / N * sum( (log (1 + y))^2 - (log (1 + y'))^2 ) )
+
+    Basically, we convert the ground truth y and predictions y' to log(1 + y),
+    log(1 + y'). Then we compute RMSE of these values.
+
+    Both the ground truth and prediction file must have a format like this:
+
+    fullVisitorId,transactionRevenue
+    1234567890,0.0
+    1234567891,0.0
+    ...
+
+
+    """
+
+    print('Loading ground truth csv: ', args.ground_truth_file)
+    gt = pd.read_csv(
+        args.ground_truth_file,
+        dtype=str).set_index('fullVisitorId')
+
+    print('Loading prediction csv: ', args.prediction_file)
+    pred = pd.read_csv(
+        args.prediction_file,
+        dtype=str).set_index('fullVisitorId')
+
+    gt = pd.to_numeric(gt['transactionRevenue'])
+    pred = pd.to_numeric(pred['transactionRevenue'])
+
+    if args.skip_log:
+        print('Computing RMSE without log.')
+        result = rmse(gt, pred)
+    else:
+        print('Computing RMSE with log.')
+        result = rmse_log(gt, pred)
+
+    print('RMSE:', result)
+
+
+def rmse_log(gt, preds):
+    """Compute the RMSE in between two series log space."""
+    return rmse(np.log(1+gt), np.log(1+preds))
+
+
+def rmse(gt, preds):
+    """Compute the RMSE between two series."""
+    # TODO: check for case where indices don't align
+    return np.sqrt(((gt - preds) * (gt - preds)).mean())
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Evaluate the RMSE of a set of predictions in log space.')
+    parser.add_argument(
+        '--ground_truth_file', default='./processed_data/val_revenues.csv',
+        help='Location where ground truth revenues are stored.',
+        type=str)
+    parser.add_argument(
+        '--prediction_file', default='./processed_data/val_sample_predictions.csv',
+        help='Location where predicted revenues are stored.',
+        type=str)
+    parser.add_argument(
+        '--skip_log', action='store_true',
+        help='Whether to skip conversion to log space. Useful if files are already converted.')
+    args=parser.parse_args()
+
+    main(args)

--- a/split_train_valid.py
+++ b/split_train_valid.py
@@ -145,6 +145,8 @@ def main(args):
         {'index': 'sumRevenue'})
     sum_revenue_val = sum_revenue_val.reset_index().rename(
         {'index': 'sumRevenue'})
+    all_zeros_val = sum_revenue_val.copy()
+    all_zeros_val['transactionRevenue'] = 0
 
     print('Saving...')
     df_trainminusval.to_csv(
@@ -161,6 +163,9 @@ def main(args):
         index=False)
     sum_revenue_val.to_csv(
         os.path.join(args.output_dir, args.output_valid_label_file),
+        index=False)
+    all_zeros_val.to_csv(
+        os.path.join(args.output_dir, args.output_valid_sample_predictions_file),
         index=False)
 
     print('Done!')
@@ -199,6 +204,10 @@ if __name__ == '__main__':
         type=str)
     parser.add_argument(
         '--output_valid_label_file', default='val_revenues.csv',
+        help='Destination file for new validation set.',
+        type=str)
+    parser.add_argument(
+        '--output_valid_sample_predictions_file', default='val_sample_predictions.csv',
         help='Destination file for new validation set.',
         type=str)
     parser.add_argument(


### PR DESCRIPTION
Made an evaluation script to test performance on the validation set. Will by default look for files called "val_revenues.csv" and "val_sample_predictions.csv" when run on the command line, but can also be imported as a module. The "val_sample_predictions.csv" is an all-zero sample prediction file generated by split_train_val.py.

Example output
```
$ python evaluate.py
Loading ground truth csv:  ./processed_data/val_revenues.csv
Loading prediction csv:  ./processed_data/val_sample_predictions.csv
Computing RMSE with log.
RMSE: 0.5634922273349524
```

I also tried running it with different train/val splits besides the "official" one in the google drive to get a sense of the variance. Results:

```
Run 1: 0.5634922273349524
Run 2: 0.596690456511786
Run 3: 0.5175336907905921
Run 4: 0.5639022693037485
Run 5: 0.5016276511167597
```